### PR TITLE
client-logger snippet

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "apostrophe-atom",
   "main": "./lib/apostrophe-atom",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Snippets for your Apostrophe projects.",
   "keywords": [],
   "repository": "https://github.com/punkave/apostrophe-atom",

--- a/snippets/apostrophe-snippets.cson
+++ b/snippets/apostrophe-snippets.cson
@@ -14,3 +14,7 @@
     'body': '{{ apos.singleton(${1:page}, \'${2:name}\', \'${3:type}\'${4:, { ${5:options} \\}}) }}'
     'description': 'Renders a single widget in your template'
     'descriptionMoreURL': 'http://apostrophenow.org/tutorials/getting-started/adding-editable-content-areas-to-your-page-templates.html'
+  'Client Logger':
+    'prefix': 'client-logger'
+    'body': '<script>console.log({{ ${1:expression} | json }})</script>'
+    'description': 'Pass any data like object to the browser console for debugging.'


### PR DESCRIPTION
Love the apos.log -- but I'll often use this instead. I find it easier parsing through the data (especially when it's a lot of info) -- when it's presented as an object in the browser console. 
